### PR TITLE
Allow for empty object

### DIFF
--- a/lib/parser/parser.ex
+++ b/lib/parser/parser.ex
@@ -154,7 +154,7 @@ defmodule KeyValues3.Parser do
       times(
         ignore(whitespace())
         |> choice([key_value_pair(), ignore(line_comment()), ignore(block_comment())]),
-        min: 1
+        min: 0
       )
       |> reduce({:pairs_to_map, []})
     )

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -42,7 +42,7 @@ defmodule ParserTest do
   end
 
   test "empty object" do
-    assert {:ok, [], "", _, _, _} = KeyValues3.Parser.value("{}")
+    assert {:ok, [%{}], "", _, _, _} = KeyValues3.Parser.value("{}")
   end
 
   test "simple object" do


### PR DESCRIPTION
Thanks for working on this library! I fortuitously was looking for something to perform this work just as you published it today.

---

I was attempting to parse some files with empty objects and realized that the empty object value is ignored completely currently resulting in subsequent key-value pairs to be off by 1.

Example file:

```
<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
{
	empty = {}
	a = 1
	b = true
}
```

Results in:

```Elixir
%{1 => "b", "empty" => "a"}
```

Rather than the expected:

```Elixir
%{"a" => 1, "b" => true, "empty" => %{}}
```